### PR TITLE
adds the `transpile` sub-command

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,6 +2,7 @@ pub mod build_derivation;
 pub mod eval;
 pub mod hash;
 pub mod show_derivation;
+pub mod transpile;
 use clap::{ArgMatches, Command};
 use colored::*;
 use std::process::ExitCode;

--- a/src/cmd/transpile.rs
+++ b/src/cmd/transpile.rs
@@ -1,0 +1,36 @@
+use crate::cmd::{to_cmd_err, RixSubCommand};
+use crate::eval::nix_v8;
+use clap::{Arg, ArgAction, ArgMatches};
+
+pub fn cmd() -> RixSubCommand {
+    return RixSubCommand {
+        name: "transpile",
+        handler: |args| to_cmd_err(handle_cmd(args)),
+        cmd: |subcommand| {
+            subcommand
+                .about("transpiles the given nix expression file into JavaScript.")
+                .arg(Arg::new("EXPRESSION").help("The nix expression to transpile."))
+                .arg(
+                    Arg::new("expr")
+                        .long("expr")
+                        .action(ArgAction::SetTrue)
+                        .help("The 'EXPRESSION' argument will be treated as an expression rather than a file."),
+                )
+        },
+    };
+}
+
+pub fn handle_cmd(parsed_args: &ArgMatches) -> Result<(), String> {
+    let expression = parsed_args
+        .get_one::<String>("EXPRESSION")
+        .ok_or("You must provide a single expression to transpile.")?;
+    let is_expression = parsed_args.get_one::<bool>("expr").unwrap();
+    if *is_expression {
+        let js_source = nix_v8::emit_module(&expression)
+            .map_err(|_err| "Failed to transpile the expression.".to_owned())?;
+        println!("{}", js_source);
+    } else {
+        todo!("Support to transpile files is not yet implemented.")
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ fn main() -> ExitCode {
         &cmd::eval::cmd(),
         &cmd::hash::cmd(),
         &cmd::show_derivation::cmd(),
+        &cmd::transpile::cmd(),
     ];
 
     for subcommand in subcommands {

--- a/tests/cmd/mod.rs
+++ b/tests/cmd/mod.rs
@@ -2,3 +2,4 @@ pub mod build_derivation;
 pub mod eval;
 pub mod hash;
 pub mod show_derivation;
+pub mod transpile;

--- a/tests/cmd/transpile.rs
+++ b/tests/cmd/transpile.rs
@@ -1,0 +1,26 @@
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+#[test]
+fn transpile_help() {
+    assert_cmd(&["--help"])
+        .success()
+        .stderr(predicate::str::is_empty());
+}
+
+#[test]
+fn transpile_bool_expr() {
+    assert_cmd(&["--expr", "1.0"])
+        .success()
+        .stdout(predicate::str::contains(
+            "export const __nix_value = 1.0;\n",
+        ))
+        .stderr(predicate::str::is_empty());
+}
+
+fn assert_cmd(eval_args: &[&str]) -> assert_cmd::assert::Assert {
+    let mut rix_args = vec!["transpile"];
+    rix_args.extend_from_slice(eval_args);
+    return Command::cargo_bin("rix").unwrap().args(rix_args).assert();
+}


### PR DESCRIPTION
This allows us to save the transpiled JavaScript file and run it with `node` or `deno`.