### PR TITLE
Added global intrinsic functions in typescript

### DIFF
--- a/nixjs-rt/src/builtins.ts
+++ b/nixjs-rt/src/builtins.ts
@@ -356,8 +356,6 @@ export function getBuiltins() {
 
       const pathValue = pathStrict.toJs();
 
-      // Below is an intrinsic function that's injected by the Nix evaluator.
-      // @ts-ignore
       const resultingFn: (ctx: EvalCtx) => NixType = importNixModule(pathValue);
 
       const ctx = new EvalCtx(pathValue);

--- a/nixjs-rt/src/globals.d.ts
+++ b/nixjs-rt/src/globals.d.ts
@@ -1,0 +1,15 @@
+import type { NixType, EvalCtx } from "./lib";
+
+declare global {
+  /**
+   * Import a Nix module from the given path. The path is absolute.
+   * Returns a transpiled version of the module, executed, with a function
+   * that takes an EvalCtx and returns the module's value.
+   */
+  var importNixModule: (path: string) => (ctx: EvalCtx) => NixType;
+
+  /**
+   * Log the string provided, purely for debugging purposes.
+   */
+  var debugLog: (log: string) => void;
+}

--- a/nixjs-rt/tsconfig.json
+++ b/nixjs-rt/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "Bundler",
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
-    "inlineSourceMap": true
+    "inlineSourceMap": true,
+    "typeRoots": ["src/globals.d.ts"]
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Added global intrinsic functions in typescript

Added global type definitions for functions we provide as intrinsics from the runtime. Also added a debug log function because I couldn't figure out how to add a console.log hook.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/urbas/rix/pull/126).
* #131
* #130
* #129
* #128
* #127
* __->__ #126