### PR TITLE
Propagate ctx around lambdas for access to current file path

### DIFF
--- a/nixjs-rt/src/builtins.ts
+++ b/nixjs-rt/src/builtins.ts
@@ -17,10 +17,11 @@ import {
   NixTypeClass,
   Path,
   TRUE,
+  toPath,
 } from "./lib";
 import { dirOf, isAbsolutePath, normalizePath } from "./utils";
 
-type BuiltinsRecord = Record<string, (param: NixType) => NixType>;
+type BuiltinsRecord = Record<string, (param: NixType, ctx: EvalCtx) => NixType>;
 
 function builtinBasicTypeMismatchError(
   fnName: string,
@@ -71,7 +72,7 @@ export function getBuiltins() {
       throw new Error("unimplemented");
     },
 
-    all: (pred) => {
+    all: (pred, ctx) => {
       const lambdaStrict = pred.toStrict();
       if (!(lambdaStrict instanceof Lambda)) {
         throw builtinBasicTypeMismatchError("all", lambdaStrict, Lambda);
@@ -84,7 +85,7 @@ export function getBuiltins() {
         }
 
         for (const element of listStrict.values) {
-          const result = lambdaStrict.apply(element);
+          const result = lambdaStrict.apply(element, ctx);
           if (!result.asBoolean()) {
             return FALSE;
           }
@@ -94,7 +95,7 @@ export function getBuiltins() {
       });
     },
 
-    any: (pred) => {
+    any: (pred, ctx) => {
       const lambdaStrict = pred.toStrict();
       if (!(lambdaStrict instanceof Lambda)) {
         throw builtinBasicTypeMismatchError("any", lambdaStrict, Lambda);
@@ -107,7 +108,7 @@ export function getBuiltins() {
         }
 
         for (const element of listStrict.values) {
-          const result = lambdaStrict.apply(element);
+          const result = lambdaStrict.apply(element, ctx);
           if (result.asBoolean()) {
             return TRUE;
           }
@@ -216,7 +217,7 @@ export function getBuiltins() {
       throw new Error("unimplemented");
     },
 
-    dirOf: (arg) => {
+    dirOf: (path) => {
       throw new Error("unimplemented");
     },
 
@@ -350,7 +351,7 @@ export function getBuiltins() {
       return listStrict.values[0];
     },
 
-    import: (path) => {
+    import: (path, ctx) => {
       const pathStrict = path.toStrict();
 
       if (!(pathStrict instanceof Path || pathStrict instanceof NixString)) {

--- a/nixjs-rt/src/legacyTests.test.ts
+++ b/nixjs-rt/src/legacyTests.test.ts
@@ -21,9 +21,9 @@ import { evalCtx, keyVals, toAttrpath } from "./testUtils";
 
 // Apply:
 test("calling a lambda should return its value", () => {
-  expect(new Lambda((_) => new NixInt(1n)).apply(EMPTY_ATTRSET)).toStrictEqual(
-    new NixInt(1n),
-  );
+  expect(
+    new Lambda((_) => new NixInt(1n)).apply(EMPTY_ATTRSET, evalCtx()),
+  ).toStrictEqual(new NixInt(1n));
 });
 
 // Arithmetic:
@@ -496,7 +496,7 @@ test("parameter lambda", () => {
   expect(
     n
       .paramLambda(evalCtx(), "foo", (evalCtx) => evalCtx.lookup("foo"))
-      .apply(n.TRUE),
+      .apply(n.TRUE, evalCtx()),
   ).toBe(n.TRUE);
 });
 

--- a/nixjs-rt/src/lib.ts
+++ b/nixjs-rt/src/lib.ts
@@ -142,7 +142,7 @@ export abstract class NixType {
     return _nixBoolFromJs(this.asBoolean() && rhs.asBoolean());
   }
 
-  apply(param: NixType): NixType {
+  apply(param: NixType, ctx: EvalCtx): NixType {
     throw invalidTypeError(
       this,
       err`Attempt to call something which is not a function but is ${errType(this)}`,
@@ -1063,8 +1063,8 @@ export class Lazy extends NixType {
     return this.toStrict().and(rhs);
   }
 
-  override apply(param: NixType): NixType {
-    return this.toStrict().apply(param);
+  override apply(param: NixType, ctx: EvalCtx): NixType {
+    return this.toStrict().apply(param, ctx);
   }
 
   override asBoolean(): boolean {
@@ -1176,15 +1176,15 @@ export class Lazy extends NixType {
 }
 
 export class Lambda extends NixType {
-  body: (param: NixType) => NixType;
+  body: (param: NixType, ctx: EvalCtx) => NixType;
 
-  constructor(body: (param: NixType) => NixType) {
+  constructor(body: (param: NixType, ctx: EvalCtx) => NixType) {
     super();
     this.body = body;
   }
 
-  override apply(param: NixType): NixType {
-    return this.body(param);
+  override apply(param: NixType, ctx: EvalCtx): NixType {
+    return this.body(param, ctx);
   }
 
   toJs(): any {

--- a/src/eval/emit_js.rs
+++ b/src/eval/emit_js.rs
@@ -49,7 +49,7 @@ fn emit_apply(apply: &ast::Apply, out_src: &mut String) -> Result<(), String> {
             .expect("Unexpected lambda application without arguments."),
         out_src,
     )?;
-    out_src.push(')');
+    out_src.push_str(", ctx)");
     Ok(())
 }
 


### PR DESCRIPTION
Propagate ctx around lambdas for access to current file path

We need to be able to access ctx for certain builtins, e.g. import which needs to know the directory of the current file to know how to handle string-based import paths.
