### PR TITLE
More robust import tests

### DIFF
--- a/nixjs-rt/src/builtins.ts
+++ b/nixjs-rt/src/builtins.ts
@@ -550,7 +550,14 @@ export function getBuiltins() {
       throw new Error("unimplemented");
     },
 
-    toString: (arg) => {
+    toString: (arg: NixType) => {
+      if (arg instanceof NixString) {
+        return arg;
+      } else if (arg instanceof Path) {
+        return new NixString(arg.path);
+      }
+
+      // TODO: Expand on this
       throw new Error("unimplemented");
     },
 

--- a/src/tests/builtins.rs
+++ b/src/tests/builtins.rs
@@ -488,9 +488,57 @@ mod import {
     #[test]
     fn eval() {
         assert_eq!(
-            eval_ok("(builtins.import ./flake.nix).description"),
-            Value::Str("A reimplementation or nix in Rust.".into())
+            eval_ok("(builtins.import ./src/tests/import_tests/basic.nix).data"),
+            Value::Str("imported!".into())
         );
+    }
+
+    #[test]
+    fn eval_same_folder_import() {
+        assert_eq!(
+            eval_ok("(builtins.import ./src/tests/import_tests/same-folder-import.nix).dataPath"),
+            Value::Str("imported!".into())
+        );
+        assert_eq!(
+            eval_ok("(builtins.import ./src/tests/import_tests/same-folder-import.nix).dataString"),
+            Value::Str("imported!".into())
+        );
+    }
+
+    #[test]
+    fn eval_child_folder_import() {
+        assert_eq!(
+            eval_ok("(builtins.import ./src/tests/import_tests/child-folder-import.nix).dataPath"),
+            Value::Str("imported!".into())
+        );
+        assert_eq!(
+            eval_ok(
+                "(builtins.import ./src/tests/import_tests/child-folder-import.nix).dataString"
+            ),
+            Value::Str("imported!".into())
+        );
+    }
+
+    #[test]
+    fn eval_parent_folder_import() {
+        assert_eq!(
+            eval_ok("(builtins.import ./src/tests/import_tests/nested/parent-folder-import.nix).dataPath"),
+            Value::Str("imported!".into())
+        );
+        assert_eq!(
+            eval_ok("(builtins.import ./src/tests/import_tests/nested/parent-folder-import.nix).dataString"),
+            Value::Str("imported!".into())
+        );
+    }
+
+    #[test]
+    fn eval_relative_string() {
+        assert_eq!(
+            eval_err(r#"builtins.import "./foo.nix""#),
+            NixErrorKind::Other {
+                codename: "builtins-import-non-absolute-path".to_owned()
+            }
+        )
     }
 
     #[test]

--- a/src/tests/import_tests/basic.nix
+++ b/src/tests/import_tests/basic.nix
@@ -1,0 +1,3 @@
+{
+  data = "imported!";
+}

--- a/src/tests/import_tests/child-folder-import.nix
+++ b/src/tests/import_tests/child-folder-import.nix
@@ -1,0 +1,4 @@
+{
+  dataPath = (builtins.import ./nested/basic.nix).data;
+  dataString = (builtins.import (builtins.toString ./nested/basic.nix)).data;
+}

--- a/src/tests/import_tests/nested/basic.nix
+++ b/src/tests/import_tests/nested/basic.nix
@@ -1,0 +1,3 @@
+{
+  data = "imported!";
+}

--- a/src/tests/import_tests/nested/parent-folder-import.nix
+++ b/src/tests/import_tests/nested/parent-folder-import.nix
@@ -1,0 +1,4 @@
+{
+  dataPath = (builtins.import ../basic.nix).data;
+  dataString = (builtins.import (builtins.toString ../basic.nix)).data;
+}

--- a/src/tests/import_tests/same-folder-import.nix
+++ b/src/tests/import_tests/same-folder-import.nix
@@ -1,0 +1,4 @@
+{
+  dataPath = (builtins.import ./basic.nix).data;
+  dataString = (builtins.import (builtins.toString ./basic.nix)).data;
+}


### PR DESCRIPTION
More robust import tests

Everything I've done in previous PRs fixed issues with these tests. They test importing both using paths and strings, importing from the same folder, from a parent folder, from a child folder.
