### PR TITLE
Improved "other" error testing with error codename

### DIFF
--- a/nixjs-rt/src/builtins.ts
+++ b/nixjs-rt/src/builtins.ts
@@ -341,7 +341,10 @@ export function getBuiltins() {
         );
       }
       if (listStrict.values.length === 0) {
-        throw otherError("Cannot fetch the first element in an empty list.");
+        throw otherError(
+          "Cannot fetch the first element in an empty list.",
+          "builtins-head-on-empty-list",
+        );
       }
       return listStrict.values[0];
     },

--- a/nixjs-rt/src/errors/other.ts
+++ b/nixjs-rt/src/errors/other.ts
@@ -2,14 +2,21 @@ import { ErrorMessage, err, NixError, instanceToClass } from ".";
 import { NixTypeClass, NixTypeInstance } from "../lib";
 
 export class NixOtherError {
-  constructor(public readonly message: string) {}
+  constructor(
+    public readonly message: ErrorMessage,
+    public readonly codename: string,
+  ) {}
 
   toDefaultErrorMessage(): ErrorMessage {
-    return err`${this.message}`;
+    return this.message;
   }
 }
 
-export function otherError(message: string) {
-  let other = new NixOtherError(message);
+export function otherError(message: string | ErrorMessage, codename: string) {
+  if (typeof message === "string") {
+    message = err`${message}`;
+  }
+
+  let other = new NixOtherError(message, codename);
   return new NixError(other, other.toDefaultErrorMessage());
 }

--- a/nixjs-rt/src/lib.ts
+++ b/nixjs-rt/src/lib.ts
@@ -535,6 +535,7 @@ class AttrsetBuilder implements Scope {
       if (attrPath.length === 0) {
         throw otherError(
           "Cannot add an undefined attribute name to the attrset.",
+          "attrset-add-undefined-attrname",
         );
       }
       const attrName = attrPath[0].toStrict();
@@ -1330,7 +1331,10 @@ function _attrPathToValue(
   value: NixType,
 ): undefined | NixType {
   if (attrPath.length === 0) {
-    throw otherError("Unexpected attr path of zero length.");
+    throw otherError(
+      "Unexpected attr path of zero length.",
+      "attrset-attrpath-zero-length",
+    );
   }
 
   let attrName = attrPath[0].toStrict();

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -72,7 +72,7 @@ pub enum NixErrorKind {
         got: NixTypeKind,
     },
     Other {
-        message: String,
+        codename: String,
     },
     MissingAttribute {
         attr_path: Vec<String>,
@@ -153,9 +153,10 @@ fn try_js_error_to_rust(
             NixErrorKind::TypeMismatch { expected, got }
         }
         "NixOtherError" => {
-            let message_js = get_js_value_key(scope, &kind_js, "message")?;
-            let message = message_js.to_rust_string_lossy(scope);
-            NixErrorKind::Other { message }
+            let codename_js = get_js_value_key(scope, &kind_js, "codename")?;
+            let codename = codename_js.to_rust_string_lossy(scope);
+
+            NixErrorKind::Other { codename }
         }
         "NixMissingAttributeError" => {
             let attr_path_js = get_js_value_key(scope, &kind_js, "attrPath")?;
@@ -211,7 +212,7 @@ fn nix_type_class_to_enum(
                 "Unexpected type name: {name}"
             ))],
             kind: NixErrorKind::Other {
-                message: format!("Unexpected type name: {name}"),
+                codename: "unknown-type".to_owned(),
             },
         }),
     }

--- a/src/tests/builtins.rs
+++ b/src/tests/builtins.rs
@@ -476,7 +476,7 @@ mod head {
         assert_eq!(
             eval_err("builtins.head []"),
             NixErrorKind::Other {
-                message: "Cannot fetch the first element in an empty list.".to_string()
+                codename: "builtins-head-on-empty-list".to_string()
             }
         );
     }


### PR DESCRIPTION
Improved "other" error testing with error codename

This should allow easier testing of more obscure error cases. I might even replace other more rarely used errors with "other" because of this.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/urbas/rix/pull/132).
* #131
* #130
* #129
* #128
* #127
* __->__ #132